### PR TITLE
Fix manually installed mods being deleted on launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ src-tauri/target
 *.pem
 *.key
 
+# Docs (draft posts, internal notes)
+docs/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ A native macOS mod manager for [Valheim](https://store.steampowered.com/app/8929
 
 1. Download `Macheim.dmg` from the [Releases](https://github.com/lofcgi/macheim/releases) page
 2. Open the DMG and drag **Macheim** to your Applications folder
-3. On first launch, if macOS blocks the app, go to **System Settings > Privacy & Security** and click **Open Anyway**
+3. **Important:** The app is not code-signed yet, so macOS will block it. Open Terminal and run:
+   ```bash
+   xattr -cr /Applications/Macheim.app
+   ```
+4. Now open Macheim normally. If macOS still blocks it, go to **System Settings > Privacy & Security** and click **Open Anyway**
 
 ### Build from Source
 

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -4,6 +4,7 @@ use tracing::info;
 
 use crate::error::AppResult;
 use crate::services::game_detector::{self, GameStatus};
+use crate::services::profile_manager;
 use crate::AppState;
 
 /// Detect the Valheim installation and store the path in app state.
@@ -19,12 +20,24 @@ pub async fn detect_game(state: tauri::State<'_, Mutex<AppState>>) -> AppResult<
             let bepinex_installed =
                 crate::services::bepinex_installer::check_bepinex_status(&game_root).installed;
 
-            let mut state = state.lock().map_err(|e| {
+            let (active_profile, game_path_was_none) = {
+                let mut state = state.lock().map_err(|e| {
+                    crate::error::AppError::GameNotFound(format!("Failed to lock state: {}", e))
+                })?;
+                let was_none = state.game_path.is_none();
+                state.game_path = Some(path.clone());
+                state.bepinex_installed = bepinex_installed;
+                (state.active_profile.clone(), was_none)
+            };
+
+            // On first detection, import any existing manually installed mods
+            if game_path_was_none && bepinex_installed {
+                let _ = profile_manager::import_existing_mods(&active_profile, &game_root);
+            }
+
+            let state = state.lock().map_err(|e| {
                 crate::error::AppError::GameNotFound(format!("Failed to lock state: {}", e))
             })?;
-            state.game_path = Some(path.clone());
-            state.bepinex_installed = bepinex_installed;
-
             let status = game_detector::get_game_status_info(&Some(path), bepinex_installed, &state.active_profile);
             Ok(status)
         }

--- a/src-tauri/src/commands/mods.rs
+++ b/src-tauri/src/commands/mods.rs
@@ -390,6 +390,40 @@ pub struct SyncResult {
     pub cleaned: Vec<String>,
 }
 
+/// List mods in the plugins directory that are not tracked by the current profile.
+/// Used by the frontend to show a confirmation dialog before cleaning.
+#[tauri::command]
+pub async fn list_unmanaged_mods(
+    state: tauri::State<'_, Mutex<AppState>>,
+) -> AppResult<Vec<String>> {
+    let (game_path, active_profile) = {
+        let s = state.lock().map_err(|e| AppError::Mod(format!("Lock: {}", e)))?;
+        let gp = s.game_path.clone().ok_or_else(|| AppError::Mod("Game not set".into()))?;
+        (gp, s.active_profile.clone())
+    };
+
+    let game_root = game_detector::get_valheim_root(&game_path);
+    let plugins_dir = game_root.join("BepInEx/plugins");
+
+    let profile = profile_manager::load_profile(&active_profile).unwrap_or_else(|_| {
+        crate::models::Profile::new(active_profile, String::new())
+    });
+
+    let profile_names: HashSet<String> = profile.mods.iter().map(|m| m.full_name.clone()).collect();
+    let mut unmanaged = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&plugins_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if entry.path().is_dir() && !name.starts_with('.') && !profile_names.contains(&name) {
+                unmanaged.push(name);
+            }
+        }
+    }
+
+    Ok(unmanaged)
+}
+
 fn emit_progress(
     app: &tauri::AppHandle,
     stage: &str, mod_name: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             commands::mods::get_installed_mods,
             commands::mods::install_modpack,
             commands::mods::sync_mods,
+            commands::mods::list_unmanaged_mods,
             // Profiles
             commands::profiles::list_profiles,
             commands::profiles::create_profile,

--- a/src-tauri/src/services/profile_manager.rs
+++ b/src-tauri/src/services/profile_manager.rs
@@ -232,6 +232,7 @@ pub fn switch_profile(profile_name: &str, game_root: &Path) -> AppResult<()> {
 }
 
 /// Save the current game BepInEx state back to a profile.
+/// Also detects untracked mods (manually installed) and adds them to profile metadata.
 pub fn save_game_state_to_profile(profile_name: &str, game_root: &Path) -> AppResult<()> {
     let profile_dir = get_profile_dir(profile_name);
     let game_bepinex = game_root.join("BepInEx");
@@ -239,6 +240,47 @@ pub fn save_game_state_to_profile(profile_name: &str, game_root: &Path) -> AppRe
 
     if !game_bepinex.exists() {
         return Ok(());
+    }
+
+    // Detect and register untracked mods before copying files
+    let plugins_dir = game_bepinex.join("plugins");
+    if plugins_dir.exists() {
+        if let Ok(mut profile) = load_profile(profile_name) {
+            let tracked: std::collections::HashSet<String> =
+                profile.mods.iter().map(|m| m.full_name.clone()).collect();
+
+            if let Ok(entries) = std::fs::read_dir(&plugins_dir) {
+                let mut added = false;
+                for entry in entries.flatten() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if entry.path().is_dir() && !name.starts_with('.') && !tracked.contains(&name) {
+                        info!("Registering untracked mod in profile '{}': {}", profile_name, name);
+                        let parts: Vec<&str> = name.splitn(2, '-').collect();
+                        let (author, mod_name) = if parts.len() == 2 {
+                            (parts[0].to_string(), parts[1].to_string())
+                        } else {
+                            ("Unknown".to_string(), name.clone())
+                        };
+                        profile.mods.push(InstalledMod {
+                            full_name: name,
+                            author,
+                            name: mod_name,
+                            version: "0.0.0".to_string(),
+                            description: "Manually installed".to_string(),
+                            enabled: true,
+                            dependencies: Vec::new(),
+                            installed_at: chrono::Utc::now().to_rfc3339(),
+                            icon: String::new(),
+                        });
+                        added = true;
+                    }
+                }
+                if added {
+                    profile.touch();
+                    let _ = save_profile(&profile);
+                }
+            }
+        }
     }
 
     let dirs_to_sync = ["plugins", "patchers", "config", "plugins_disabled"];
@@ -256,6 +298,57 @@ pub fn save_game_state_to_profile(profile_name: &str, game_root: &Path) -> AppRe
 
     debug!("Saved game state to profile: {}", profile_name);
     Ok(())
+}
+
+/// Import existing mods from the game directory into a profile.
+/// Called on first launch when user already has manually installed mods.
+pub fn import_existing_mods(profile_name: &str, game_root: &Path) -> AppResult<Vec<String>> {
+    let game_plugins = game_root.join("BepInEx/plugins");
+    if !game_plugins.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut profile = load_profile(profile_name)?;
+    let tracked: std::collections::HashSet<String> =
+        profile.mods.iter().map(|m| m.full_name.clone()).collect();
+
+    let mut imported = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&game_plugins) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if entry.path().is_dir() && !name.starts_with('.') && !tracked.contains(&name) {
+                let parts: Vec<&str> = name.splitn(2, '-').collect();
+                let (author, mod_name) = if parts.len() == 2 {
+                    (parts[0].to_string(), parts[1].to_string())
+                } else {
+                    ("Unknown".to_string(), name.clone())
+                };
+                profile.mods.push(InstalledMod {
+                    full_name: name.clone(),
+                    author,
+                    name: mod_name,
+                    version: "0.0.0".to_string(),
+                    description: "Manually installed".to_string(),
+                    enabled: true,
+                    dependencies: Vec::new(),
+                    installed_at: chrono::Utc::now().to_rfc3339(),
+                    icon: String::new(),
+                });
+                imported.push(name);
+            }
+        }
+    }
+
+    if !imported.is_empty() {
+        info!("Imported {} existing mods into profile '{}'", imported.len(), profile_name);
+        // Also copy game BepInEx state to the profile directory
+        save_game_state_to_profile(profile_name, game_root)?;
+        profile.touch();
+        save_profile(&profile)?;
+    }
+
+    Ok(imported)
 }
 
 /// Add a mod to a profile's metadata.

--- a/src/components/mods/InstalledModList.tsx
+++ b/src/components/mods/InstalledModList.tsx
@@ -16,6 +16,7 @@ import {
   toggleMod,
   uninstallMod,
   syncMods,
+  listUnmanagedMods,
 } from "../../lib/tauri";
 
 export default function InstalledModList() {
@@ -164,7 +165,17 @@ export default function InstalledModList() {
             onClick={async () => {
               setSyncing(true);
               try {
-                const result = await syncMods(true);
+                // Check for unmanaged mods before cleaning
+                const unmanaged = await listUnmanagedMods();
+                let doClean = false;
+                if (unmanaged.length > 0) {
+                  doClean = window.confirm(
+                    `The following ${unmanaged.length} mod(s) are not managed by Macheim and will be removed:\n\n` +
+                    unmanaged.join("\n") +
+                    "\n\nProceed with cleanup?"
+                  );
+                }
+                const result = await syncMods(doClean);
                 const msgs: string[] = [];
                 if (result.reinstalled.length > 0) msgs.push(`${result.reinstalled.length} reinstalled`);
                 if (result.cleaned.length > 0) msgs.push(`${result.cleaned.length} cleaned`);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -80,6 +80,10 @@ export async function syncMods(cleanUnmanaged?: boolean): Promise<SyncResult> {
   return invoke<SyncResult>("sync_mods", { cleanUnmanaged: cleanUnmanaged ?? false });
 }
 
+export async function listUnmanagedMods(): Promise<string[]> {
+  return invoke<string[]>("list_unmanaged_mods");
+}
+
 // ── Profiles ────────────────────────────────────────────────────
 
 export async function listProfiles(): Promise<Profile[]> {


### PR DESCRIPTION
## Summary

Fixes a critical bug where Macheim deletes all manually installed mods when the app is launched.

**Root cause:** The Default profile is created with an empty `BepInEx/plugins/` directory. When `switch_profile()` runs, it unconditionally deletes the game's `plugins/` directory and replaces it with the profile's content — wiping all manually installed mods.

**Changes:**

- **Auto-import existing mods on first launch** (`commands/game.rs`)
  - When Macheim detects the game for the first time, it scans `BepInEx/plugins/` and registers any existing mods into the active profile's metadata
  
- **Preserve untracked mods during profile save** (`services/profile_manager.rs`)
  - `save_game_state_to_profile()` now detects mod directories not in the profile metadata and auto-registers them before saving
  - New `import_existing_mods()` function for explicit import

- **Confirmation before cleaning unmanaged mods** (`commands/mods.rs`, `InstalledModList.tsx`)
  - New `list_unmanaged_mods` Tauri command returns mods not tracked by the current profile
  - Sync & Clean button now shows a confirmation dialog listing mods that will be removed, instead of silently deleting them

- **README: Gatekeeper fix** 
  - Added `xattr -cr /Applications/Macheim.app` instruction for the "damaged app" error on unsigned builds

## Files changed

| File | Change |
|------|--------|
| `src-tauri/src/services/profile_manager.rs` | Auto-register untracked mods in `save_game_state_to_profile()`, add `import_existing_mods()` |
| `src-tauri/src/commands/game.rs` | Import existing mods on first game detection |
| `src-tauri/src/commands/mods.rs` | Add `list_unmanaged_mods` command |
| `src-tauri/src/lib.rs` | Register new command |
| `src/lib/tauri.ts` | Add `listUnmanagedMods()` binding |
| `src/components/mods/InstalledModList.tsx` | Confirmation dialog before clean |
| `README.md` | Add xattr instruction for Gatekeeper |
| `.gitignore` | Add docs/ |

## Test plan

- [ ] Place mod folders manually in `BepInEx/plugins/` before launching Macheim
- [ ] Launch Macheim — verify mods appear in the Installed Mods list
- [ ] Switch profiles and switch back — verify manually installed mods are preserved
- [ ] Click Sync & Clean — verify confirmation dialog appears listing unmanaged mods
- [ ] Cancel the dialog — verify no mods are deleted
- [ ] Confirm the dialog — verify only listed mods are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)