### PR TITLE
Allow console when launching modded game

### DIFF
--- a/src-tauri/src/services/launcher.rs
+++ b/src-tauri/src/services/launcher.rs
@@ -91,7 +91,7 @@ arch -x86_64 env \
   DOORSTOP_TARGET_ASSEMBLY='{preloader}' \
   DYLD_LIBRARY_PATH='{game_root}/' \
   DYLD_INSERT_LIBRARIES='{doorstop}' \
-  '{executable}'
+  '{executable}' -console
 "#,
         game_root = game_root.display(),
         preloader = preloader.display(),


### PR DESCRIPTION
See issue https://github.com/lofcgi/macheim/issues/4

When modded game is open from Macheim it will allow opening the console by default.